### PR TITLE
Improve WebSocket logging and binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ kill $SIM_PID $DASH_PID   # stop sim & web-server
 |---------|-------------|
 | **`404` when opening the dashboard** | Make sure you ran `trunk serve` from the `viz_web/` directory *after* running `cargo install trunk`.  The default URL is <http://localhost:9000>. |
 | **Smoke test hangs on WebSocket** | Confirm the demo was started with `--serve-dash 8080` and that no firewall blocks WS traffic. |
+| **Dashboard shows `Disconnected`** | Check the browser console for detailed WebSocket logs.  Ensure the simulation printed `WebSocket server listening` and that the URL matches `ws://<host>:8080/ws`. |
 | **`wasm32-unknown-unknown` target missing** | Run `rustup target add wasm32-unknown-unknown`. |
 | **Node script complains about `ws`** | Install test deps with `npm i -g ws node-fetch`. |
 | **Particles render but controls do nothing** | Check browser console — setters are exported as `set_particle_size_scale` and `set_energy_filter_min`; refresh page after rebuilding dashboard. |

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -682,9 +682,10 @@ async fn start_websocket_server(port: u16, tx: broadcast::Sender<String>) {
     
     let routes = websocket_route.with(cors);
     
-    println!("WebSocket server listening on ws://localhost:{}/ws", port);
+    println!("WebSocket server listening on ws://0.0.0.0:{}/ws", port);
+    // Bind on all interfaces so the dashboard can connect from any host
     warp::serve(routes)
-        .run(([127, 0, 0, 1], port))
+        .run(([0, 0, 0, 0], port))
         .await;
 }
 
@@ -692,6 +693,8 @@ async fn handle_websocket(websocket: warp::ws::WebSocket, tx: broadcast::Sender<
     use futures_util::{SinkExt, StreamExt};
     use warp::ws::Message;
     
+    println!("WebSocket client connected");
+
     let (mut ws_tx, mut ws_rx) = websocket.split();
     let mut rx = tx.subscribe();
     
@@ -714,6 +717,7 @@ async fn handle_websocket(websocket: warp::ws::WebSocket, tx: broadcast::Sender<
             match result {
                 Ok(msg) => {
                     if msg.is_close() {
+                        println!("WebSocket client disconnected");
                         break;
                     }
                 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -682,8 +682,8 @@ async fn start_websocket_server(port: u16, tx: broadcast::Sender<String>) {
     
     let routes = websocket_route.with(cors);
     
-    println!("WebSocket server listening on ws://0.0.0.0:{}/ws", port);
-    // Bind on all interfaces so the dashboard can connect from any host
+    println!("WebSocket server listening on ws://localhost:{}/ws", port);
+    // Note: The server is bound to all interfaces (0.0.0.0), but 'localhost' is recommended for local connections.
     warp::serve(routes)
         .run(([0, 0, 0, 0], port))
         .await;

--- a/viz_web/src/main.rs
+++ b/viz_web/src/main.rs
@@ -349,7 +349,14 @@ impl EvolutionMonitor {
     
     /// Establish websocket and start reading JSON messages representing SimulationState
     pub fn connect_ws(&mut self, websocket_url: String) {
-        let ws = web_sys::WebSocket::new(&websocket_url).unwrap();
+        console_log!("Connecting to WebSocket at {}", websocket_url);
+        let ws = match web_sys::WebSocket::new(&websocket_url) {
+            Ok(ws) => ws,
+            Err(err) => {
+                console_log!("Failed to create WebSocket: {:?}", err);
+                return;
+            }
+        };
         
         // Set up connection success handler
         let onopen_callback = Closure::wrap(Box::new(move |_: web_sys::Event| {
@@ -371,6 +378,8 @@ impl EvolutionMonitor {
                 let data_str = text.as_string().unwrap_or_default();
                 console_log!("Received WebSocket message: {}", data_str);
                 // TODO: Parse and update simulation state
+            } else {
+                console_log!("Received non-text WebSocket message");
             }
         }) as Box<dyn FnMut(MessageEvent)>);
         

--- a/viz_web/src/main.rs
+++ b/viz_web/src/main.rs
@@ -379,7 +379,11 @@ impl EvolutionMonitor {
                 console_log!("Received WebSocket message: {}", data_str);
                 // TODO: Parse and update simulation state
             } else {
-                console_log!("Received non-text WebSocket message");
+                let message_type = match e.data().dyn_into::<ArrayBuffer>() {
+                    Ok(buffer) => format!("binary (size: {} bytes)", buffer.byte_length()),
+                    Err(_) => "unknown type".to_string(),
+                };
+                console_log!("Received non-text WebSocket message: {}", message_type);
             }
         }) as Box<dyn FnMut(MessageEvent)>);
         


### PR DESCRIPTION
## Summary
- bind the websocket server on `0.0.0.0` so external dashboards can connect
- add connect/disconnect logs to the server
- log websocket connection attempts and non‑text messages on the wasm side
- mention troubleshooting tip when the dashboard shows disconnected

## Testing
- `cargo check --workspace`
- `node tools/smoke_dashboard.js` *(fails: dashboard HTTP not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_684e06798da48323aa0f2b7ad8034fb4